### PR TITLE
feat: build caddy/calibre images when docker-bake changes

### DIFF
--- a/.github/workflows/build-caddy.yaml
+++ b/.github/workflows/build-caddy.yaml
@@ -8,6 +8,7 @@ on:
       - ".github/workflows/build-caddy.yaml"
       - ".github/workflows/build-image.yaml"
       - "caddy/Dockerfile"
+      - "docker-bake.hcl"
   pull_request:
     branches:
       - main
@@ -15,6 +16,7 @@ on:
       - ".github/workflows/build-caddy.yaml"
       - ".github/workflows/build-image.yaml"
       - "caddy/Dockerfile"
+      - "docker-bake.hcl"
   workflow_dispatch:
 
 permissions: {}
@@ -28,6 +30,9 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.get-version.outputs.version }}
+      tags: ${{ steps.get-tags.outputs.tags }}
+    permissions:
+      packages: read
     steps:
       - name: Checkout the repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -39,8 +44,15 @@ jobs:
         id: get-version
         run: |
           echo "version=$(docker buildx bake --file docker-bake.hcl caddy --print | jq -r '.target.caddy.args.CADDY_VERSION')" >> $GITHUB_OUTPUT
+      - name: Get latest published caddy tag
+        id: get-tags
+        run: |
+          echo "tags=$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /user/packages/container/caddy/versions | jq -cr 'sort_by(-.id)[0].metadata.container.tags' || echo '[]')" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
   build-caddy:
+    if: ${{ !contains(fromJson(needs.get-versions.outputs.tags), needs.get-versions.outputs.version) || github.event_name == 'workflow_dispatch' }}
     permissions:
       packages: write
       attestations: write

--- a/.github/workflows/build-calibre.yaml
+++ b/.github/workflows/build-calibre.yaml
@@ -8,6 +8,7 @@ on:
       - ".github/workflows/build-calibre.yaml"
       - ".github/workflows/build-image.yaml"
       - "calibre/Dockerfile"
+      - "docker-bake.hcl"
   pull_request:
     branches:
       - main
@@ -15,6 +16,7 @@ on:
       - ".github/workflows/build-calibre.yaml"
       - ".github/workflows/build-image.yaml"
       - "calibre/Dockerfile"
+      - "docker-bake.hcl"
   workflow_dispatch:
 
 permissions: {}
@@ -28,6 +30,9 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.get-version.outputs.version }}
+      tags: ${{ steps.get-tags.outputs.tags }}
+    permissions:
+      packages: read
     steps:
       - name: Checkout the repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -39,8 +44,15 @@ jobs:
         id: get-version
         run: |
           echo "version=$(docker buildx bake --file docker-bake.hcl calibre --print | jq -r '.target.calibre.args | .CALIBRE_VERSION + "-" + .UBUNTU_VERSION')" >> $GITHUB_OUTPUT
+      - name: Get latest published calibre tag
+        id: get-tags
+        run: |
+          echo "tags=$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /user/packages/container/calibre/versions | jq -cr 'sort_by(-.id)[0].metadata.container.tags' || echo '[]')" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
   build-calibre:
+    if: ${{ !contains(fromJson(needs.get-versions.outputs.tags), needs.get-versions.outputs.version) || github.event_name == 'workflow_dispatch' }}
     permissions:
       packages: write
       attestations: write

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -44,7 +44,7 @@ target "calibre" {
     "CALIBRE_VERSION" = "${CALIBRE_VERSION}"
     "UBUNTU_VERSION" = "${UBUNTU_VERSION}"
   }
-  tags = [ "ghcr.io/bryanwweber/calibre:${CALIBRE_VERSION}-1", "ghcr.io/bryanwweber/calibre:latest" ]
+  tags = [ "ghcr.io/bryanwweber/calibre:${CALIBRE_VERSION}-${UBUNTU_VERSION}", "ghcr.io/bryanwweber/calibre:latest" ]
   platforms = [ "linux/amd64", "linux/arm64" ]
   labels = {
     "org.opencontainers.image.description" = "This image runs a Calibre server for managing eBooks."


### PR DESCRIPTION
Check whether the version is published before building on push. Always build if workflow_dispatch is used to make sure there's an override.