### PR TITLE
copy caddy conf into the image

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -13,7 +13,6 @@ ATUIN_DB_PASSWORD="op://App Deployment/Atuin DB Password/password"
 # Caddy
 NAMECHEAP_API_KEY="op://App Deployment/Namecheap API Key/credential"
 NAMECHEAP_API_USER="op://App Deployment/Namecheap API Key/username"
-CADDY_CONFIG_ROOT=${CADDY_CONFIG_ROOT:-./conf}
 PUBLIC_CLIENT_IP=${PUBLIC_CLIENT_IP}
 
 # Calibre

--- a/.github/workflows/build-caddy.yaml
+++ b/.github/workflows/build-caddy.yaml
@@ -8,6 +8,7 @@ on:
       - ".github/workflows/build-caddy.yaml"
       - ".github/workflows/build-image.yaml"
       - "caddy/Dockerfile"
+      - "caddy/conf/Caddyfile"
       - "docker-bake.hcl"
   pull_request:
     branches:
@@ -16,6 +17,7 @@ on:
       - ".github/workflows/build-caddy.yaml"
       - ".github/workflows/build-image.yaml"
       - "caddy/Dockerfile"
+      - "caddy/conf/Caddyfile"
       - "docker-bake.hcl"
   workflow_dispatch:
 
@@ -43,7 +45,7 @@ jobs:
       - name: Get latest caddy version
         id: get-version
         run: |
-          echo "version=$(docker buildx bake --file docker-bake.hcl caddy --print | jq -r '.target.caddy.args.CADDY_VERSION')" >> $GITHUB_OUTPUT
+          echo "version=$(docker buildx bake --file docker-bake.hcl caddy --print | jq -r '.target.caddy.args | .CADDY_VERSION + "-" + .CADDY_DNS_NAMECHEAP_VERSION')" >> $GITHUB_OUTPUT
       - name: Get latest published caddy tag
         id: get-tags
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -55,14 +55,12 @@ jobs:
       - name: Pull and restart the containers
         run: |
           source versions.sh
-          rsync -vzR ./caddy/conf/Caddyfile ${HETZNER_USER}@${HETZNER_HOST}:/tmp/
           op run --env-file .env.tpl -- docker compose down
           op run --env-file .env.tpl -- docker compose pull --quiet
           op run --env-file .env.tpl -- docker compose up --detach --wait --wait-timeout 30
         env:
           HETZNER_USER: ${{ vars.HETZNER_USER }}
           HETZNER_HOST: ${{ vars.HETZNER_HOST }}
-          CADDY_CONFIG_ROOT: /tmp/caddy/conf
           DOCKER_HOST: ssh://${{ vars.HETZNER_USER }}@${{ vars.HETZNER_HOST }}
           PUBLIC_CLIENT_IP: ${{ secrets.PUBLIC_CLIENT_IP }}
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -1,9 +1,11 @@
-ARG CADDY_VERSION=2.10.2
+ARG CADDY_VERSION
 FROM caddy:${CADDY_VERSION}-builder-alpine AS builder
+ARG CADDY_DNS_NAMECHEAP_VERSION
 
 RUN xcaddy build \
-    --with github.com/caddy-dns/namecheap@master
+    --with github.com/caddy-dns/namecheap@v${CADDY_DNS_NAMECHEAP_VERSION}
 
 FROM caddy:${CADDY_VERSION}-alpine AS final
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+COPY ./conf/Caddyfile /etc/caddy/Caddyfile

--- a/caddy/docker-compose.yml
+++ b/caddy/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       retries: 60
     restart: unless-stopped
   caddy:
-    image: ghcr.io/bryanwweber/caddy:${CADDY_VERSION}
+    image: ghcr.io/bryanwweber/caddy:${CADDY_VERSION}-${CADDY_DNS_NAMECHEAP_VERSION}
     restart: unless-stopped
     environment:
       - PUBLIC_CLIENT_IP=${PUBLIC_CLIENT_IP}
@@ -31,7 +31,6 @@ services:
       ts-caddy:
         condition: service_healthy
     volumes:
-      - ${CADDY_CONFIG_ROOT}:/etc/caddy
       - caddy_data:/data
       - caddy_config:/config
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -8,6 +8,10 @@ variable "CADDY_VERSION" {
   default = "2.10.2"
 }
 
+variable "CADDY_DNS_NAMECHEAP_VERSION" {
+  default = "1.0.0"
+}
+
 variable "CALIBRE_VERSION" {
   default = "9.2.1"
 }
@@ -22,8 +26,9 @@ target "caddy" {
   dockerfile = "Dockerfile"
   args = {
     "CADDY_VERSION" = "${CADDY_VERSION}"
+    "CADDY_DNS_NAMECHEAP_VERSION" = "${CADDY_DNS_NAMECHEAP_VERSION}"
   }
-  tags = [ "ghcr.io/bryanwweber/caddy:${CADDY_VERSION}", "ghcr.io/bryanwweber/caddy:latest" ]
+  tags = [ "ghcr.io/bryanwweber/caddy:${CADDY_VERSION}-${CADDY_DNS_NAMECHEAP_VERSION}", "ghcr.io/bryanwweber/caddy:latest" ]
   platforms = [ "linux/amd64", "linux/arm64" ]
   attest = [
     {


### PR DESCRIPTION
The tradeoff is that changes to the config are a little harder to deploy, but the config should be pretty stable at this point. The upside is that the config doesn't have to get rsynced to `/tmp` with the permissions failures.